### PR TITLE
added Github flavoured syntax highlighting to code samples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,27 +44,27 @@ The `Router` can listen to `Window.onPopState` events and invoke the correct
 handler so that the back button seamlessly works.
 
 Example (client.dart):
+```dart
+library client;
 
-    library client;
+import 'package:route/client.dart';
 
-    import 'package:route/client.dart';
+main() {
+  var router = new Router();
+  router.addHandler(homeUrl, showHome);
+  router.addHandler(articleUrl, showArticle);
+}
 
-    main() {
-      var router = new Router();
-      router.addHandler(homeUrl, showHome);
-      router.addHandler(articleUrl, showArticle);
-    }
+void showHome(String path) {
+  // nothing to parse from path, since there are no groups
+}
 
-    void showHome(String path) {
-      // nothing to parse from path, since there are no groups
-    }
-
-    void showArticle(String path) {
-      var articleId = articleUrl.parse(req.path)[0];
-      // show article page with loading indicator
-      // load article from server, then render article
-    }
-
+void showArticle(String path) {
+  var articleId = articleUrl.parse(req.path)[0];
+  // show article page with loading indicator
+  // load article from server, then render article
+}
+```
 Server Routing
 --------------
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ URL has the form /article/1234. We want to show articles without reloading the
 page.
 
 Example (urls.dart):
+
 ```dart
 library urls;
 
@@ -45,6 +46,7 @@ The `Router` can listen to `Window.onPopState` events and invoke the correct
 handler so that the back button seamlessly works.
 
 Example (client.dart):
+
 ```dart
 library client;
 
@@ -72,6 +74,7 @@ Server Routing
 
 On the server, route gives you a utility function to match `HttpRequest`s
 against `UrlPatterns`.
+
 ```dart
 import 'urls.dart';
 import 'package:route/server.dart';

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ UrlPattern
 
 Route is built around `UrlPattern` a class that matches, parses and produces
 URLs. A `UrlPattern` is similar to a regex, but constrained so that it is
-_reversible_, given a `UrlPattern` and a set or arguments you can produce the
+_reversible_, given a `UrlPattern` and a set of arguments you can produce the
 URL that when parsed returns those same arguments. This is important for keeping
 the URL space for your app flexible so that you can change a URL for a resource
 in one place and keep your app working.
@@ -22,14 +22,15 @@ URL has the form /article/1234. We want to show articles without reloading the
 page.
 
 Example (urls.dart):
+```dart
+library urls;
 
-    library urls;
+import 'package:route/url_pattern.dart';
 
-    import 'package:route/url_pattern.dart';
-
-    final homeUrl = new UrlPattern(r'/');
-    final articleUrl = new UrlPattern(r'/article/(\d+)');
-    final allUrls = [homeUrl, articleUrl];
+final homeUrl = new UrlPattern(r'/');
+final articleUrl = new UrlPattern(r'/article/(\d+)');
+final allUrls = [homeUrl, articleUrl];
+```
 
 Client Routing
 --------------
@@ -65,39 +66,41 @@ void showArticle(String path) {
   // load article from server, then render article
 }
 ```
+
 Server Routing
 --------------
 
 On the server, route gives you a utility function to match `HttpRequest`s
 against `UrlPatterns`.
+```dart
+import 'urls.dart';
+import 'package:route/server.dart';
 
-    import 'urls.dart';
-    import 'package:route/server.dart';
+import 'package:route/server.dart';
+import 'package:route/pattern.dart';
 
-    import 'package:route/server.dart';
-    import 'package:route/pattern.dart';
+HttpServer.bind().then((server) {
+  var router = new Router(server);
+  router.filter(matchesAny(allUrls), authFilter);
+  router.serve(homeUrl).listen(serverHome);
+  router.serve(articleUrl).listen(serveArticle);
+});
 
-    HttpServer.bind().then((server) {
-      var router = new Router(server);
-      router.filter(matchesAny(allUrls), authFilter);
-      router.serve(homeUrl).listen(serverHome);
-      router.serve(articleUrl).listen(serveArticle);
-    });
-
-    Future<bool> authFilter(req) {
-      return getUser(getUserIdCookie(req)).then((user) {
-        if (user != null) {
-          return true;
-        }
-        serveLoginPage(req);
-        return false;
-      });
+Future<bool> authFilter(req) {
+  return getUser(getUserIdCookie(req)).then((user) {
+    if (user != null) {
+      return true;
     }
+    serveLoginPage(req);
+    return false;
+  });
+}
 
-    serveArcticle(req) {
-      var articleId = articleUrl.parse(req.path)[0];
-      // retreive article data
-    }
+serveArcticle(req) {
+  var articleId = articleUrl.parse(req.path)[0];
+  // retreive article data
+}
+```
 
 Further Goals
 -------------


### PR DESCRIPTION
I put all code samples in README.md in Fenced code-blocks (enclosed in triple backticks, ```). This turns on syntax highlighting in Github Flavoured Markdown.

Plus I fixed a minor typo.
