### PR TITLE
Routing on page load

### DIFF
--- a/test/client_listen_fragment.html
+++ b/test/client_listen_fragment.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved. Use of this source code is governed by a
+BSD-style license that can be found in the LICENSE file.
+-->
+<html lang="en">
+  <head>
+    <title>client_test</title>
+    <div><a id="a_with_path" href="/path">/path</a></div>
+    <div><a id="a_with_fragment" href="#fragment">#fragment</a></div>
+  </head>
+  <body>
+    <script type="application/javascript">
+if (navigator.webkitStartDart) {
+  navigator.webkitStartDart();
+}
+    </script>
+    <script type="application/dart">
+import 'dart:html';
+import 'package:unittest/unittest.dart';
+import 'package:route/client.dart';
+
+main() {
+  test('route on hash changed when useFragment == true', () {
+    var router = new Router(useFragment: true);
+    var urlWithFragment = new UrlPattern(r'(.*)#fragment');
+    router.addHandler(urlWithFragment, expectAsync1((String path) {
+      expect(path, predicate((p) => p.endsWith('fragment')));
+    }));
+    router.listen();
+    window.location.hash = "fragment";
+  });
+}
+    </script>
+  </body>
+</html>

--- a/test/client_listen_fragment_start.html
+++ b/test/client_listen_fragment_start.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved. Use of this source code is governed by a
+BSD-style license that can be found in the LICENSE file.
+-->
+<html lang="en">
+  <head>
+    <title>client_test</title>
+    <div><a id="a_with_path" href="/path">/path</a></div>
+    <div><a id="a_with_fragment" href="#fragment">#fragment</a></div>
+  </head>
+  <body>
+    <script type="application/javascript">
+if (navigator.webkitStartDart) {
+  navigator.webkitStartDart();
+}
+    </script>
+    <script type="application/dart">
+import 'dart:html';
+import 'package:unittest/unittest.dart';
+import 'package:route/client.dart';
+
+main() {
+  test('route after calling listen when useFragment == true', () {
+    var router = new Router(useFragment: true);
+    var urlWithFragment = new UrlPattern(r'(.*)#fragment');
+    router.addHandler(urlWithFragment, expectAsync1((String path) {
+      expect(path, predicate((p) => p.endsWith('fragment')));
+    }));
+    window.location.hash = "fragment";
+    expect(router.listen(), true);
+  });
+}
+    </script>
+  </body>
+</html>

--- a/test/client_listen_popstate.html
+++ b/test/client_listen_popstate.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved. Use of this source code is governed by a
+BSD-style license that can be found in the LICENSE file.
+-->
+<html lang="en">
+  <head>
+    <title>client_test</title>
+    <div><a id="a_with_path" href="/path">/path</a></div>
+    <div><a id="a_with_fragment" href="#fragment">#fragment</a></div>
+  </head>
+  <body>
+    <script type="application/javascript">
+if (navigator.webkitStartDart) {
+  navigator.webkitStartDart();
+}
+    </script>
+    <script type="application/dart">
+import 'dart:html';
+import 'package:unittest/unittest.dart';
+import 'package:route/client.dart';
+
+main() {
+  test('route on url changed', () {
+    var router = new Router();
+    var urlBar = new UrlPattern(r'(.*)/bar');
+    var urlFoo = new UrlPattern(r'(.*)/foo');
+    router.addHandler(urlBar, expectAsync1((String path) {
+      expect(path, predicate((p) => p.endsWith('bar')));
+    }));
+    router.addHandler(urlFoo, (String path) {});
+    window.history.pushState(null, '', '${window.location}/bar');
+    window.history.pushState(null, '', '${window.location}/foo');
+    router.listen();
+    window.history.back();
+  });
+}
+    </script>
+  </body>
+</html>

--- a/test/client_listen_popstate_start.html
+++ b/test/client_listen_popstate_start.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved. Use of this source code is governed by a
+BSD-style license that can be found in the LICENSE file.
+-->
+<html lang="en">
+  <head>
+    <title>client_test</title>
+    <div><a id="a_with_path" href="/path">/path</a></div>
+    <div><a id="a_with_fragment" href="#fragment">#fragment</a></div>
+  </head>
+  <body>
+    <script type="application/javascript">
+if (navigator.webkitStartDart) {
+  navigator.webkitStartDart();
+}
+    </script>
+    <script type="application/dart">
+import 'dart:html';
+import 'package:unittest/unittest.dart';
+import 'package:route/client.dart';
+
+main() {
+  test('route after calling listen', () {
+    var router = new Router();
+    var url = new UrlPattern(r'(.*)/bar');
+    router.addHandler(url, expectAsync1((String path) {
+      expect(path, predicate((p) => p.endsWith('bar')));
+    }));
+    window.history.pushState(null, '', '${window.location}/bar');
+    expect(router.listen(), true);
+  });
+}
+    </script>
+  </body>
+</html>

--- a/test/client_test.html
+++ b/test/client_test.html
@@ -55,6 +55,36 @@ main() {
     router.handle(testPathFragment);
   });
 
+  group('prevent handling the same path twice with pushState after', () {
+    var router;
+    var url = new UrlPattern(r'/foo#(\d+)');
+    var testPath = '/foo/123';
+    setUp(() {
+      router = new Router();
+    });
+    test('handle', () {
+      router.addHandler(url, expectAsync1((String path) {
+        expect(path, predicate((p) => p.endsWith('/foo/123')));
+      }));
+      router.handle(testPath);
+      router.handle(testPath);
+    });
+    test('gotoPath', () {
+      router.addHandler(url, expectAsync1((String path) {
+        expect(path, predicate((p) => p.endsWith('/foo/123')));
+      }));
+      router.gotoPath(testPath, '');
+      router.handle(testPath);
+    });
+    test('gotoUrl', () {
+      router.addHandler(url, expectAsync1((String path) {
+        expect(path, predicate((p) => p.endsWith('/foo/123')));
+      }));
+      router.gotoUrl(url, ['123'], '');
+      router.handle(testPath);
+    });
+  });
+
   test('click handler with fragment is routed when useFragment == true', () {
     var router = new Router(useFragment: true);
     var urlWithFragment = new UrlPattern(r'(.*)#fragment');


### PR DESCRIPTION
A proposal to fix the issue of Browsers behave differently on page load. If you start listening with a router in Chrome this will fire a handler on page load. In Firefox it doesn't.

`Browsers tend to handle the popstate event differently on page load. Chrome and Safari always emit a popstate event on page load, but Firefox doesn't.` see https://developer.mozilla.org/en-US/docs/DOM/window.onpopstate

To create a consistent behavior I copied the concept of Backbone's routing. Backbone routes by default when you starting the history. see https://github.com/documentcloud/backbone/blob/master/backbone.js#L1417
We also could implement a silent option to prevent routing on app start.

Further Changes:
- Added a couple more tests.
- Listen returns a bool which indicates if an UrlPattern matched on page load.
